### PR TITLE
Add logger for ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ import {
   logger as BNLogger
 } from "@bonniernews/logger";
 import express from "express";
-import pino from "pino";
 
 const logger = BNLogger();
 const app = express();

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
 export { fetchGcpProjectId } from "./lib/gcp";
 export { getHttpTraceHeader } from "./lib/http";
-export { getLoggingTraceData } from "./lib/logging";
+export { getLoggingTraceData, logger } from "./lib/logging";
 export { middleware } from "./lib/middleware";

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -1,10 +1,11 @@
+import pino, { DestinationStream, LoggerOptions } from "pino";
 import { getGcpProjectId } from "./gcp";
 import { getStore } from "./middleware";
 import { getTraceFromTraceparent } from "./traceparent";
 
 export function getLoggingTraceData() {
   const { traceparent, ...rest } = getStore();
-  if (!traceparent) return {};
+  if (!traceparent) return rest;
 
   const trace = getTraceFromTraceparent(traceparent);
   if (!trace) return rest;
@@ -12,10 +13,7 @@ export function getLoggingTraceData() {
   const logData = { traceId: trace.traceId, spanId: trace.parentId, ...rest };
 
   const gcpProjectId = getGcpProjectId();
-  if (!gcpProjectId) {
-    console.log("GCP Project ID not found");
-    return logData;
-  }
+  if (!gcpProjectId) return logData;
 
   return {
     ...logData,
@@ -25,73 +23,74 @@ export function getLoggingTraceData() {
   };
 }
 
-// TODO: This is a copy of exp-logger, implement this
-// export function buildLogger(opts: SomeType) {
-//   return pino({ opts, mixin: getLoggingTraceData });
-// }
+type BnLoggerOptions = Omit<LoggerOptions, "level" | "formatters"> & {
+  logLevel?: "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+  formatLog?: NonNullable<LoggerOptions["formatters"]>["log"];
+};
 
-// function severity(label) {
-//   switch (label) {
-//     case "trace":
-//       return "DEBUG";
-//     case "debug":
-//       return "DEBUG";
-//     case "info":
-//       return "INFO";
-//     case "warn":
-//       return "WARNING";
-//     case "error":
-//       return "ERROR";
-//     case "fatal":
-//       return "CRITICAL";
-//     default:
-//       return "DEFAULT";
-//   }
-// }
+export function logger(options: BnLoggerOptions = {}, stream?: DestinationStream | undefined) {
+  const env = process.env.NODE_ENV /* c8 ignore next */ || "development";
+  const shouldPrettyPrint = ["development", "test", "dev"].includes(env) && !stream;
 
-// /**
-//  * @typedef LoggerOptions
-//  * @property {string} options.logLevel="info" which level of severity to log at
-//  * @property {function} options.mixin mixin for additional information in the log statement
-//  * @property {function} [options.formatLog] function to do change the shape of the log object
-//  */
+  const logLocation = env === "test" && "./logs/test.log";
 
-// /** @typedef {import("pino").Logger} Logger */
+  const {
+    logLevel: level = "info",
+    base = undefined,
+    messageKey = "message",
+    timestamp = () => `,"time": "${new Date().toISOString()}"`,
+    formatLog,
+    /* c8 ignore start */
+    transport = shouldPrettyPrint
+      ? {
+          target: "pino-pretty",
+          options: {
+            destination: logLocation || 1,
+            colorize: !logLocation,
+            messageKey: "message",
+          },
+        }
+      : undefined,
+    /* c8 ignore stop */
+    mixin,
+    ...rest
+  } = options;
 
-// /**
-//  * @param {LoggerOptions} options
-//  * @return {Logger} the logger.
-//  *
-//  */
-// function init(options) {
-//   const env = process.env.NODE_ENV || "development";
-//   const shouldPrettyPrint = ["development", "test", "dev"].includes(env);
+  return pino(
+    {
+      level,
+      base,
+      messageKey,
+      timestamp,
+      formatters: {
+        level: (label) =>
+          shouldPrettyPrint ? /* c8 ignore next */ { level: label } : { severity: gcpSeverity(label) },
+        ...(formatLog && { log: formatLog }),
+      },
+      transport,
+      mixin: (...args) => ({ ...getLoggingTraceData(), ...mixin?.(...args) }),
+      ...rest,
+    },
+    stream
+  );
+}
 
-//   const logLocation = env === "test" && "./logs/test.log";
-//   return pino({
-//     level: options?.logLevel ?? "info",
-//     messageKey: "message",
-//     base: undefined,
-//     formatters: {
-//       level(label) {
-//         if (shouldPrettyPrint) {
-//           return { level: label };
-//         }
-//         return { severity: severity(label) };
-//       },
-//       ...(options?.formatLog && { log: options?.formatLog }),
-//     },
-//     timestamp: () => `,"time": "${new Date().toISOString()}"`,
-//     transport: shouldPrettyPrint
-//       ? {
-//           target: "pino-pretty",
-//           options: {
-//             destination: logLocation || 1,
-//             colorize: !logLocation,
-//             messageKey: "message",
-//           },
-//         }
-//       : undefined,
-//     mixin: options?.mixin,
-//   });
-// }
+function gcpSeverity(label: string) {
+  switch (label) {
+    case "trace":
+      return "DEBUG";
+    case "debug":
+      return "DEBUG";
+    case "info":
+      return "INFO";
+    case "warn":
+      return "WARNING";
+    case "error":
+      return "ERROR";
+    case "fatal":
+      return "CRITICAL";
+    /* c8 ignore next 2 */
+    default:
+      return "DEFAULT";
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@bonniernews/logger",
       "version": "0.0.5",
       "license": "MIT",
+      "dependencies": {
+        "pino": "^9.5.0",
+        "pino-pretty": "^11.3.0"
+      },
       "devDependencies": {
         "@bonniernews/tsconfig": "^0.0.2",
         "@types/chai": "^5.0.0",
@@ -22,8 +26,6 @@
         "express": "^4.21.0",
         "mocha": "^10.7.3",
         "mocha-cakes-2": "^3.3.0",
-        "pino": "^9.4.0",
-        "pino-test": "^1.1.0",
         "prettier": "^3.3.3",
         "sinon": "^19.0.2",
         "tsx": "^4.19.1",
@@ -1294,6 +1296,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1439,7 +1453,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -1450,6 +1463,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/bignumber.js": {
@@ -1547,6 +1580,30 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1752,6 +1809,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1819,6 +1882,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1947,6 +2019,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2207,6 +2288,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
@@ -2274,6 +2373,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2329,11 +2434,16 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
       "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -2760,6 +2870,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2810,6 +2926,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3029,6 +3165,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-yaml": {
@@ -3286,6 +3431,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -3521,7 +3675,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3544,7 +3697,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3701,7 +3853,6 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
       "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -3724,28 +3875,41 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
       "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.3.0.tgz",
+      "integrity": "sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
       }
     },
     "node_modules/pino-std-serializers": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pino-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pino-test/-/pino-test-1.1.0.tgz",
-      "integrity": "sha512-eAD3qqt23jiJrwAWHSEdKyBRUjflodcTW14u9i/k4sdDsIT0r3v1cv+JyLJERFYfWgVkqAjgfOCkHVFiPNvpmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.2.0"
-      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -3773,11 +3937,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
       "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -3792,6 +3964,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -3845,7 +4027,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/randombytes": {
@@ -3884,6 +4065,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3901,7 +4098,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -3976,7 +4172,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3997,7 +4192,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4009,6 +4203,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -4214,7 +4414,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
       "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -4224,7 +4423,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -4238,6 +4436,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -4302,7 +4509,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4397,7 +4603,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
@@ -4709,7 +4914,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
   },
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "pino": "^9.5.0",
+    "pino-pretty": "^11.3.0"
+  },
   "devDependencies": {
     "@bonniernews/tsconfig": "^0.0.2",
     "@types/chai": "^5.0.0",
@@ -38,8 +42,6 @@
     "express": "^4.21.0",
     "mocha": "^10.7.3",
     "mocha-cakes-2": "^3.3.0",
-    "pino": "^9.4.0",
-    "pino-test": "^1.1.0",
     "prettier": "^3.3.3",
     "sinon": "^19.0.2",
     "tsx": "^4.19.1",

--- a/test/feature/logging.test.ts
+++ b/test/feature/logging.test.ts
@@ -2,14 +2,13 @@ import gcpMetaData from "gcp-metadata";
 import pino from "pino";
 import { createSandbox } from "sinon";
 import { fetchGcpProjectId, reset } from "../../lib/gcp";
-import { getLoggingTraceData } from "../../lib/logging";
+import { logger as BNLogger } from "../../lib/logging";
 import { middleware } from "../../lib/middleware";
 
-const logs: string[] = [];
-const stream = {
-  write: (data: string) => logs.push(data),
-};
-const logger = pino({ mixin: getLoggingTraceData }, stream);
+const logs: Record<string, unknown>[] = [];
+const stream = { write: (data: string) => logs.push(JSON.parse(data)) };
+
+const logger = BNLogger({}, stream);
 
 const sandbox = createSandbox();
 
@@ -17,7 +16,7 @@ const traceId = "0af7651916cd43dd8448eb211c80319c";
 const spanId = "b7ad6b7169203331";
 const traceparent = `00-${traceId}-${spanId}-01`;
 
-Feature("Logging", () => {
+Feature("Logging with tracing", () => {
   afterEachScenario(() => {
     logs.length = 0;
     sandbox.restore();
@@ -40,9 +39,8 @@ Feature("Logging", () => {
 
     Then("trace data should be logged", () => {
       expect(logs.length).to.equal(1);
-      const log = JSON.parse(logs[0]);
-      expect(log).to.deep.include({
-        msg: "test",
+      expect(logs[0]).to.deep.include({
+        message: "test",
         traceId,
         spanId,
         "logging.googleapis.com/trace": `projects/test-project/traces/${traceId}`,
@@ -68,9 +66,8 @@ Feature("Logging", () => {
 
     Then("no trace data should be logged", () => {
       expect(logs.length).to.equal(1);
-      const log = JSON.parse(logs[0]);
-      expect(log).to.deep.include({ msg: "test" });
-      expect(log).not.to.have.all.keys([
+      expect(logs[0]).to.deep.include({ message: "test" });
+      expect(logs[0]).not.to.have.all.keys([
         "traceId",
         "spanId",
         "logging.googleapis.com/trace",
@@ -96,9 +93,8 @@ Feature("Logging", () => {
 
     Then("no trace data should be logged", () => {
       expect(logs.length).to.equal(1);
-      const log = JSON.parse(logs[0]);
-      expect(log).to.deep.include({ msg: "test" });
-      expect(log).not.to.have.all.keys([
+      expect(logs[0]).to.deep.include({ message: "test" });
+      expect(logs[0]).not.to.have.all.keys([
         "traceId",
         "spanId",
         "logging.googleapis.com/trace",
@@ -115,9 +111,8 @@ Feature("Logging", () => {
 
     Then("no trace data should be logged", () => {
       expect(logs.length).to.equal(1);
-      const log = JSON.parse(logs[0]);
-      expect(log).to.deep.include({ msg: "test" });
-      expect(log).not.to.have.all.keys([
+      expect(logs[0]).to.deep.include({ message: "test" });
+      expect(logs[0]).not.to.have.all.keys([
         "traceId",
         "spanId",
         "logging.googleapis.com/trace",
@@ -142,15 +137,133 @@ Feature("Logging", () => {
 
     Then("trace data should be logged", () => {
       expect(logs.length).to.equal(1);
-      const log = JSON.parse(logs[0]);
-      expect(log).to.deep.include({ msg: "test" });
-      expect(log).not.to.have.all.keys([
+      expect(logs[0]).to.deep.include({ message: "test" });
+      expect(logs[0]).not.to.have.all.keys([
         "traceId",
         "spanId",
         "logging.googleapis.com/trace",
         "logging.googleapis.com/spanId",
         "logging.googleapis.com/trace_sampled",
       ]);
+    });
+  });
+});
+
+Feature("GCP logging severities", () => {
+  afterEachScenario(() => {
+    logs.length = 0;
+  });
+
+  Scenario("Logging at info level", () => {
+    When("logging at info level", () => {
+      logger.info("test");
+    });
+
+    Then("the GCP severity should be INFO", () => {
+      expect(logs.length).to.equal(1);
+      expect(logs[0]).to.deep.include({
+        message: "test",
+        severity: "INFO",
+      });
+    });
+  });
+
+  Scenario("Logging at fatal level", () => {
+    When("logging at fatal level", () => {
+      logger.fatal("test");
+    });
+
+    Then("the GCP severity should be CRITICAL", () => {
+      expect(logs.length).to.equal(1);
+      expect(logs[0]).to.deep.include({
+        message: "test",
+        severity: "CRITICAL",
+      });
+    });
+  });
+});
+
+Feature("Logging options", () => {
+  afterEachScenario(() => {
+    logs.length = 0;
+    sandbox.restore();
+    reset();
+  });
+
+  Scenario("Logging with custom mixin", () => {
+    let localLogger: pino.Logger;
+    Given("a logger with a custom mixin", () => {
+      localLogger = BNLogger({ mixin: () => ({ foo: "bar" }) }, stream);
+    });
+
+    When("logging", () => {
+      localLogger.info("test");
+    });
+
+    Then("custom mixin data should be logged", () => {
+      expect(logs.length).to.equal(1);
+      expect(logs[0]).to.deep.include({
+        message: "test",
+        foo: "bar",
+      });
+    });
+  });
+
+  Scenario("Logging with custom mixin and trace context", () => {
+    let localLogger: pino.Logger;
+    Given("a logger with a custom mixin", () => {
+      localLogger = BNLogger({ mixin: () => ({ foo: "bar" }) }, stream);
+    });
+
+    And("we can fetch the GCP project ID from the metadata server", async () => {
+      sandbox.stub(gcpMetaData, "isAvailable").resolves(true);
+      sandbox.stub(gcpMetaData, "project").resolves("test-project");
+      await fetchGcpProjectId();
+    });
+
+    When("logging in the middleware context", () => {
+      // @ts-expect-error - We don't need the full Express Request object
+      middleware({ header: () => traceparent }, {}, () => {
+        localLogger.info("test");
+      });
+    });
+
+    Then("custom mixin data should be merged with trace data and logged", () => {
+      expect(logs.length).to.equal(1);
+      expect(logs[0]).to.deep.include({
+        message: "test",
+        foo: "bar",
+        traceId,
+        spanId,
+        "logging.googleapis.com/trace": `projects/test-project/traces/${traceId}`,
+        "logging.googleapis.com/spanId": spanId,
+        "logging.googleapis.com/trace_sampled": true,
+      });
+    });
+  });
+
+  Scenario("Logging with `formatLog`", () => {
+    let localLogger: pino.Logger;
+    Given("a logger with a custom mixin", () => {
+      localLogger = BNLogger(
+        {
+          formatLog: (obj) => {
+            return Object.fromEntries(Object.entries(obj).map(([key, value]) => [key.toUpperCase(), value]));
+          },
+        },
+        stream
+      );
+    });
+
+    When("logging", () => {
+      localLogger.info({ foo: "bar" }, "test");
+    });
+
+    Then("the formatter should be used", () => {
+      expect(logs.length).to.equal(1);
+      expect(logs[0]).to.deep.include({
+        FOO: "bar",
+      });
     });
   });
 });


### PR DESCRIPTION
This logger duplicates the interface of exp-logger, making this a drop-in replacement. It also exposes everything that can be passed to `pino`, making it more flexible.