### PR TITLE
Make `gcp-metadata` dependency not optional

### DIFF
--- a/lib/gcp.ts
+++ b/lib/gcp.ts
@@ -1,3 +1,5 @@
+import gcpMetaData from "gcp-metadata";
+
 let gcpProjectId: string | undefined = undefined;
 
 export function getGcpProjectId() {
@@ -10,16 +12,6 @@ export function getGcpProjectId() {
  * You only need to call this function if you're not setting the `GCP_PROJECT` environment variable.
  */
 export async function fetchGcpProjectId() {
-  let gcpMetaData;
-  /* c8 ignore start */
-  try {
-    gcpMetaData = await import("gcp-metadata");
-  } catch {
-    console.error("Failed to import gcp-metadata module");
-    return;
-  }
-  /* c8 ignore stop */
-
   const isAvailable = await gcpMetaData.isAvailable();
   if (!isAvailable) return;
 
@@ -29,6 +21,6 @@ export async function fetchGcpProjectId() {
 /**
  * Resets the GCP project ID, for testing.
  */
-export async function reset() {
+export function reset() {
   gcpProjectId = undefined;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
+        "gcp-metadata": "^6.1.0",
         "pino": "^9.5.0",
         "pino-pretty": "^11.3.0"
       },
@@ -31,9 +32,6 @@
         "tsx": "^4.19.1",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.12.1"
-      },
-      "optionalDependencies": {
-        "gcp-metadata": "^6.1.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1350,7 +1348,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
       "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -1490,7 +1487,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -1897,7 +1893,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2370,8 +2365,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "3.0.2",
@@ -2639,7 +2633,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -2656,7 +2649,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
       "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "json-bigint": "^1.0.0"
@@ -2905,7 +2897,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
       "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -3084,7 +3075,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -3194,7 +3184,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -3583,7 +3572,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -3632,7 +3620,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4635,8 +4622,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
@@ -4792,7 +4778,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4826,15 +4811,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "gcp-metadata": "^6.1.0",
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0"
   },
@@ -47,8 +48,5 @@
     "tsx": "^4.19.1",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.12.1"
-  },
-  "optionalDependencies": {
-    "gcp-metadata": "^6.1.0"
   }
 }


### PR DESCRIPTION
This makes installation easier (though it might install an extra unnecessary dependency if run outside GCP), and we want to optimize for ease of use.