### PR TITLE
Create new traceparent if no header was provided 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,3 +2,4 @@ export { fetchGcpProjectId } from "./lib/gcp";
 export { getHttpTraceHeader } from "./lib/http";
 export { getLoggingTraceData, logger } from "./lib/logging";
 export { middleware } from "./lib/middleware";
+export { createTraceparent } from "./lib/traceparent";

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from "express";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { createTraceparent } from "./traceparent";
 
 type Store = {
   traceparent?: string;
@@ -10,7 +11,7 @@ type Store = {
 const storage = new AsyncLocalStorage<Store>();
 
 export const middleware: RequestHandler = (req, _res, next) => {
-  const traceparent = req.header("traceparent");
+  const traceparent = req.header("traceparent") || createTraceparent();
 
   storage.run({ traceparent }, () => {
     next();

--- a/lib/traceparent.ts
+++ b/lib/traceparent.ts
@@ -1,3 +1,5 @@
+import crypto from "crypto";
+
 /**
  * Traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00
  *
@@ -16,4 +18,13 @@ export function getTraceFromTraceparent(traceHeader: string) {
     parentId: parts[2],
     isSampled: parts[3] !== "00",
   };
+}
+
+export function createTraceparent(isSampled: boolean = false) {
+  const version = "00";
+  const traceId = crypto.randomBytes(16).toString("hex");
+  const parentId = crypto.randomBytes(8).toString("hex");
+  const flags = isSampled ? "01" : "00";
+
+  return `${version}-${traceId}-${parentId}-${flags}`;
 }

--- a/test/unit/middleware.test.ts
+++ b/test/unit/middleware.test.ts
@@ -11,6 +11,16 @@ describe("Express middleware", () => {
     });
   });
 
+  it("should create a new traceparent and store it in the store if no traceparent header was provided", () => {
+    const req = { header: () => {} };
+
+    // @ts-expect-error - We don't need the full Express Request object
+    middleware(req, {}, () => {
+      const traceparent = getStore().traceparent || "";
+      expect(new RegExp(/^[\da-f-]{55}$/).test(traceparent)).to.equal(true);
+    });
+  });
+
   it("should return an empty object if the middleware is not used", () => {
     expect(getStore()).to.deep.equal({});
   });

--- a/test/unit/traceparent.test.ts
+++ b/test/unit/traceparent.test.ts
@@ -1,4 +1,4 @@
-import { getTraceFromTraceparent } from "../../lib/traceparent";
+import { getTraceFromTraceparent, createTraceparent } from "../../lib/traceparent";
 
 describe("Traceparent parsing", () => {
   it("should parse a traceparent header correctly", async () => {
@@ -19,5 +19,27 @@ describe("Traceparent parsing", () => {
     const trace = getTraceFromTraceparent(traceparent);
 
     expect(trace).to.equal(undefined);
+  });
+});
+
+describe("Traceparent creation", () => {
+  it("should create a traceparent header correctly", async () => {
+    const traceparent = createTraceparent();
+    const [version, traceId, parentId, isSampled] = traceparent.split("-");
+
+    expect(version).to.equal("00"); // we only support version 00
+    expect(isSampled).to.equal("00"); // default is not sampled
+
+    expect(new RegExp(/^[\da-f]{2}$/).test(version)).to.equal(true, version);
+    expect(new RegExp(/^[\da-f]{32}$/).test(traceId)).to.equal(true, traceId);
+    expect(new RegExp(/^[\da-f]{16}$/).test(parentId)).to.equal(true, parentId);
+    expect(new RegExp(/^[\da-f]{2}$/).test(isSampled)).to.equal(true, isSampled);
+  });
+
+  it("Sets flags if passed isSampled true", async () => {
+    const traceparent = createTraceparent(true);
+    const [, , , isSampled] = traceparent.split("-");
+
+    expect(isSampled).to.equal("01");
   });
 });


### PR DESCRIPTION
This PR updates our middleware to create a new traceparent if no traceparent header is provided. It also exposes the traceparent generation function in the library's public API, making it easy for users to create a new traceparent in environments like Cloud Run jobs, where GCP does not automatically generate one.