### PR TITLE
Future proofing isSampled

### DIFF
--- a/lib/traceparent.ts
+++ b/lib/traceparent.ts
@@ -6,7 +6,7 @@
  * base16(parent-id) = 00f067aa0ba902b7
  * base16(trace-flags) = 00  // 00 is not sampled, 01 is sampled
  */
-function isSampled (traceFlags) {
+export function isSampled (traceFlags) {
   const FLAG_SAMPLED = 0b00000001;
   return (parseInt(traceFlags, 16) & FLAG_SAMPLED) === FLAG_SAMPLED;
 }

--- a/lib/traceparent.ts
+++ b/lib/traceparent.ts
@@ -6,7 +6,7 @@
  * base16(parent-id) = 00f067aa0ba902b7
  * base16(trace-flags) = 00  // 00 is not sampled, 01 is sampled
  */
-export function isSampled (traceFlags) {
+export function isSampled(traceFlags) {
   const FLAG_SAMPLED = 0b00000001;
   return (parseInt(traceFlags, 16) & FLAG_SAMPLED) === FLAG_SAMPLED;
 }

--- a/lib/traceparent.ts
+++ b/lib/traceparent.ts
@@ -6,7 +6,7 @@
  * base16(parent-id) = 00f067aa0ba902b7
  * base16(trace-flags) = 00  // 00 is not sampled, 01 is sampled
  */
-export function isSampled(traceFlags: string): boolean {
+function isSampled(traceFlags: string) {
   const FLAG_SAMPLED = 0b00000001;
   return (parseInt(traceFlags, 16) & FLAG_SAMPLED) === FLAG_SAMPLED;
 }

--- a/lib/traceparent.ts
+++ b/lib/traceparent.ts
@@ -6,7 +6,7 @@
  * base16(parent-id) = 00f067aa0ba902b7
  * base16(trace-flags) = 00  // 00 is not sampled, 01 is sampled
  */
-export function isSampled(traceFlags) {
+export function isSampled(traceFlags: string): boolean {
   const FLAG_SAMPLED = 0b00000001;
   return (parseInt(traceFlags, 16) & FLAG_SAMPLED) === FLAG_SAMPLED;
 }

--- a/lib/traceparent.ts
+++ b/lib/traceparent.ts
@@ -6,6 +6,11 @@
  * base16(parent-id) = 00f067aa0ba902b7
  * base16(trace-flags) = 00  // 00 is not sampled, 01 is sampled
  */
+function isSampled (traceFlags) {
+  const FLAG_SAMPLED = 0b00000001;
+  return (parseInt(traceFlags, 16) & FLAG_SAMPLED) === FLAG_SAMPLED;
+}
+
 export function getTraceFromTraceparent(traceHeader: string) {
   const parts = traceHeader.split("-");
 
@@ -14,6 +19,6 @@ export function getTraceFromTraceparent(traceHeader: string) {
   return {
     traceId: parts[1],
     parentId: parts[2],
-    isSampled: parts[3] !== "00",
+    isSampled: isSampled(parts[3]),
   };
 }

--- a/test/unit/traceparent.test.ts
+++ b/test/unit/traceparent.test.ts
@@ -1,4 +1,4 @@
-import { getTraceFromTraceparent } from "../../lib/traceparent";
+import { getTraceFromTraceparent, isSampled } from "../../lib/traceparent";
 
 describe("Traceparent parsing", () => {
   it("should parse a traceparent header correctly", async () => {
@@ -20,4 +20,18 @@ describe("Traceparent parsing", () => {
 
     expect(trace).to.equal(undefined);
   });
+
+  describe('isSampled', () => { 
+    [
+      { input: "00", expected: false },
+      { input: "01", expected: true },
+      { input: "02", expected: false },
+      { input: "03", expected: true },
+      { input: "ff", expected: true },
+    ].forEach(({ input, expected }) => {
+      it(`Should calculate isSampled("${input}") as ${expected}`, () => {
+        expect(isSampled(input)).to.equal(expected);
+      });
+    });
+   })
 });

--- a/test/unit/traceparent.test.ts
+++ b/test/unit/traceparent.test.ts
@@ -21,7 +21,7 @@ describe("Traceparent parsing", () => {
     expect(trace).to.equal(undefined);
   });
 
-  describe('isSampled', () => { 
+  describe("isSampled", () => {
     [
       { input: "00", expected: false },
       { input: "01", expected: true },
@@ -33,5 +33,5 @@ describe("Traceparent parsing", () => {
         expect(isSampled(input)).to.equal(expected);
       });
     });
-   })
+  });
 });

--- a/test/unit/traceparent.test.ts
+++ b/test/unit/traceparent.test.ts
@@ -1,4 +1,4 @@
-import { getTraceFromTraceparent, isSampled } from "../../lib/traceparent";
+import { getTraceFromTraceparent } from "../../lib/traceparent";
 
 describe("Traceparent parsing", () => {
   it("should parse a traceparent header correctly", async () => {
@@ -28,9 +28,11 @@ describe("Traceparent parsing", () => {
       { input: "02", expected: false },
       { input: "03", expected: true },
       { input: "ff", expected: true },
+      { input: "bar", expected: false },
     ].forEach(({ input, expected }) => {
-      it(`Should calculate isSampled("${input}") as ${expected}`, () => {
-        expect(isSampled(input)).to.equal(expected);
+      it(`Should calculate trace-flags "${input}" as isSampled: ${expected}`, () => {
+        const traceparent = `00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-${input}`;
+        expect(getTraceFromTraceparent(traceparent)?.isSampled).to.equal(expected);
       });
     });
   });


### PR DESCRIPTION
Future prooing the calculation of `isSampled`.

The Trace Context specification only now supports 1 trace flag meaning the current implementation works.
However if the specification decides to add more flags it could lead to `isSampled` being incorrectly set.

E.g. `traceFlags: "02"` would set `isSampled` when the least significant bit `FLAG_SAMPLED` actually is not set.

Make sure we only check if the `FLAG_SAMPLED`bit is set when calculating `isSampled`. 