### PR TITLE
do not import gcp-metadata rabbithole, if not needed

### DIFF
--- a/lib/gcp.ts
+++ b/lib/gcp.ts
@@ -1,5 +1,3 @@
-import gcpMetaData from "gcp-metadata";
-
 /**
  * Fetches the Google Cloud Platform (GCP) project ID from the GCP metadata server.
  *
@@ -9,7 +7,7 @@ export async function getGcpProjectId(): Promise<string | undefined> {
   if (process.env.GCP_PROJECT) {
     return process.env.GCP_PROJECT;
   }
-
+  const gcpMetaData = await import("gcp-metadata");
   const isAvailable = await gcpMetaData.isAvailable();
   if (!isAvailable) return;
 

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -55,6 +55,7 @@ export function logger(options: LoggerOptions = {}, stream?: DestinationStream |
     messageKey = "message",
     timestamp = () => `,"time": "${new Date().toISOString()}"`,
     formatLog,
+    /* c8 ignore start */
     transport = shouldPrettyPrint
       ? {
         target: "pino-pretty",
@@ -65,6 +66,7 @@ export function logger(options: LoggerOptions = {}, stream?: DestinationStream |
         },
       }
       : undefined,
+    /* c8 ignore stop */
     mixin,
     ...rest
   } = options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/logger",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/logger",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "gcp-metadata": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/logger",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Some simple functions to use Trace Context for correlating logs",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Cloud run imports are slow as is. Do not make it worse.
`gcp-metadata` pulls `gaxios` and `json-bigint`, always.
Should also be replaced with
```
const metadata = await fetch("http://metadata.google.internal/computeMetadata/v1/project/project-id", {
    headers: {
    "Metadata-Flavor": "Google",
  },
});
```
since node 18+ is required.