### PR TITLE
Retry initialize if it fails

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -18,8 +18,8 @@ export const middleware: Middleware = () => {
 
   return async (req, _res, next) => {
     if (!initialized) {
-      initialized = true;
       projectId = await getGcpProjectId();
+      initialized = !!projectId;
     }
 
     const traceparent = req.header("traceparent") || createTraceparent();


### PR DESCRIPTION
Retry initialize if it failed to check out a valid project id.

I've seen several times in my service that we can't fetch the project id from the metadata server fast enough meaning many of our logs will not be properly annotated. In this case I think it makes sense to retry the initialize.

We could instead increase the timeout but it will never be completely robust in case of latency issues.

I'm aware that this causes a `fetch` request every time when developing locally. Should we expose a config for this somehow or make it clear in docs that it is a good idea to set the env var `GCP_PROJECT` when running locally?